### PR TITLE
Specifies the range of lengths of passwords to generate

### DIFF
--- a/password_generator.py
+++ b/password_generator.py
@@ -1,5 +1,6 @@
 import string
 
+from error_message import ErrorMessage
 from character_type import CharacterType
 
 
@@ -8,7 +9,40 @@ class PasswordGenerator:
     def __init__(self) -> None:
         self.types = dict()
 
-        self.types["uppercase"] = CharacterType(list(string.ascii_uppercase))
-        self.types["lowercase"] = CharacterType(list(string.ascii_lowercase))
-        self.types["digits"] = CharacterType(list(string.digits))
-        self.types["special"] = CharacterType(list(set(string.punctuation)))
+        self._min = 8
+        self._max = 16
+
+        self.types = {
+            "uppercase": CharacterType(list(string.ascii_uppercase)),
+            "lowercase": CharacterType(list(string.ascii_lowercase)),
+            "digits": CharacterType(list(string.digits)),
+            "special": CharacterType(list(set(string.punctuation)))
+        }
+
+    def validate_range(self, min: int, max: int) -> None:
+        if type(min) != int or type(max) != int:
+            raise ValueError(ErrorMessage.MIN_MAX_NOT_NUMBERIC.value)
+
+        if min < 0 or max < 0:
+            raise ValueError(ErrorMessage.MIN_MAX_NAGATIVE.value)
+
+        if min > max:
+            raise ValueError(ErrorMessage.MIN_MAX_INVALID_RANGE.value)
+
+    @property
+    def min(self) -> int:
+        return self._min
+
+    @min.setter
+    def min(self, value: int) -> None:
+        self.validate_range(value, self._max)
+        self._min = value
+
+    @property
+    def max(self) -> int:
+        return self._max
+
+    @max.setter
+    def max(self, value: int) -> None:
+        self.validate_range(self._min, value)
+        self._max = value

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4,6 +4,7 @@ import sys
 import unittest
 
 from password_generator import PasswordGenerator
+from error_message import ErrorMessage
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 
@@ -25,20 +26,35 @@ class TestPasswordGenerator(unittest.TestCase):
             self.assertListEqual(
                 self.generator.types[name].candidate, candidate)
 
-    def test_set_min_and_max_of_character_type_(self) -> None:
-        common_types = [
-            ('uppercase', 0, 16),
-            ('lowercase', 1, 12),
-            ('digits', 2, 6),
-            ('special', 5, 5)
-        ]
+    def test_set_min_greater_than_max(self):
+        expected = ErrorMessage.MIN_MAX_INVALID_RANGE.value
 
-        for name, min, max in common_types:
-            self.generator.types[name].min = min
-            self.generator.types[name].max = max
+        for min in range(1, 10):
+            with self.assertRaisesRegex(ValueError, expected):
+                self.generator.min = min
+                self.generator.max = min - 1
 
-            self.assertEqual(self.generator.types[name].min, min)
-            self.assertEqual(self.generator.types[name].max, max)
+    def test_set_non_numberic_min_max(self) -> None:
+        nums = ["123", "d", 'A', "$"]
+        expected = ErrorMessage.MIN_MAX_NOT_NUMBERIC.value
+
+        for num in nums:
+            with self.assertRaisesRegex(ValueError, expected):
+                self.generator.min = num
+
+            with self.assertRaisesRegex(ValueError, expected):
+                self.generator.max = num
+
+    def test_set_negative_number_min_max(self) -> None:
+        nums = [-1, -3, -11]
+        expected = ErrorMessage.MIN_MAX_NAGATIVE.value
+
+        for num in nums:
+            with self.assertRaisesRegex(ValueError, expected):
+                self.generator.min = num
+
+            with self.assertRaisesRegex(ValueError, expected):
+                self.generator.max = num
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
MIN and MAX have been added as member variables to the PasswordGenerator class to specify the password length range.

However, duplicate code is occurring because the logic has a similar purpose to MIN and MAX, which are member variables of CharacterType.

Refactoring is needed to fix this.