### PR TITLE
Add the ability to adjust the length of the password to be generated

### DIFF
--- a/error_message.py
+++ b/error_message.py
@@ -9,3 +9,4 @@ class ErrorMessage(Enum):
     EMPTY_CANDIDATE = "At least one candidate character must be specified."
     GENERATE_LENGTH_OUT_OF_RANGE = "The length of the character list must be equal to or greater than min and equal to or less than max."
     GENERATE_LENGTH_NOT_NUMBERIC = "The generate length must be numberic."
+    EMPTY_CHAR_TYPE_LIST = "At least one character type must be added to the list of character types."

--- a/error_message.py
+++ b/error_message.py
@@ -10,3 +10,4 @@ class ErrorMessage(Enum):
     GENERATE_LENGTH_OUT_OF_RANGE = "The length of the character list must be equal to or greater than min and equal to or less than max."
     GENERATE_LENGTH_NOT_NUMBERIC = "The generate length must be numberic."
     EMPTY_CHAR_TYPE_LIST = "At least one character type must be added to the list of character types."
+    NOT_CHARACTER_TYPE = "A character type list can contain only CharacterType types."

--- a/error_message.py
+++ b/error_message.py
@@ -11,3 +11,5 @@ class ErrorMessage(Enum):
     GENERATE_LENGTH_NOT_NUMBERIC = "The generate length must be numberic."
     EMPTY_CHAR_TYPE_LIST = "At least one character type must be added to the list of character types."
     NOT_CHARACTER_TYPE = "A character type list can contain only CharacterType types."
+    GENERATOR_MAX_LT_CHAR_TYPE_MIN = "The password generator's MAX value must be greater than the MIN of the character type."
+    GENERATOR_MIN_GT_CHAR_TYPE_MAX = "The password generator's MIN value must be less than the character type's MAX."

--- a/error_message.py
+++ b/error_message.py
@@ -13,3 +13,4 @@ class ErrorMessage(Enum):
     NOT_CHARACTER_TYPE = "A character type list can contain only CharacterType types."
     GENERATOR_MAX_LT_CHAR_TYPE_MIN = "The password generator's MAX value must be greater than the MIN of the character type."
     GENERATOR_MIN_GT_CHAR_TYPE_MAX = "The password generator's MIN value must be less than the character type's MAX."
+    ADJUST_MAX_IS_ZERO = "The MAX value to adjust must be a positive number."

--- a/error_message.py
+++ b/error_message.py
@@ -13,4 +13,5 @@ class ErrorMessage(Enum):
     NOT_CHARACTER_TYPE = "A character type list can contain only CharacterType types."
     GENERATOR_MAX_LT_CHAR_TYPE_MIN = "The password generator's MAX value must be greater than the MIN of the character type."
     GENERATOR_MIN_GT_CHAR_TYPE_MAX = "The password generator's MIN value must be less than the character type's MAX."
+    GENERATOR_MAX_NOT_POSITIVE = "MAX only accepts positive numbers greater than or equal to 1." 
     ADJUST_MAX_IS_ZERO = "The MAX value to adjust must be a positive number."

--- a/password_generator.py
+++ b/password_generator.py
@@ -37,6 +37,13 @@ class PasswordGenerator:
             if type(char_type) != CharacterType:
                 raise TypeError(ErrorMessage.NOT_CHARACTER_TYPE.value)
 
+    def validate_adjust_range(self, min: int, max: int) -> None:
+        if min > self.max:
+            raise ValueError(ErrorMessage.GENERATOR_MAX_LT_CHAR_TYPE_MIN.value)
+
+        if max < self.min:
+            raise ValueError(ErrorMessage.GENERATOR_MIN_GT_CHAR_TYPE_MAX.value)
+
     @property
     def min(self) -> int:
         return self._min
@@ -65,3 +72,8 @@ class PasswordGenerator:
             max += type.max
 
         return (min, max)
+
+    def adjust_length(self) -> None:
+        min, max = self.sum_range()
+
+        self.validate_adjust_range(min, max)

--- a/password_generator.py
+++ b/password_generator.py
@@ -46,3 +46,12 @@ class PasswordGenerator:
     def max(self, value: int) -> None:
         self.validate_range(self._min, value)
         self._max = value
+
+    def sum_range(self) -> tuple:
+        min, max = 0, 0
+
+        for type in self.types.values():
+            min += type.min
+            max += type.max
+
+        return (min, max)

--- a/password_generator.py
+++ b/password_generator.py
@@ -29,6 +29,10 @@ class PasswordGenerator:
         if min > max:
             raise ValueError(ErrorMessage.MIN_MAX_INVALID_RANGE.value)
 
+    def validate_char_types(self) -> None:
+        if not self.types:
+            raise ValueError(ErrorMessage.EMPTY_CHAR_TYPE_LIST.value)
+
     @property
     def min(self) -> int:
         return self._min
@@ -48,6 +52,8 @@ class PasswordGenerator:
         self._max = value
 
     def sum_range(self) -> tuple:
+        self.validate_char_types()
+
         min, max = 0, 0
 
         for type in self.types.values():

--- a/password_generator.py
+++ b/password_generator.py
@@ -26,6 +26,9 @@ class PasswordGenerator:
         if min < 0 or max < 0:
             raise ValueError(ErrorMessage.MIN_MAX_NAGATIVE.value)
 
+        if max <= 0:
+            raise ValueError(ErrorMessage.GENERATOR_MAX_NOT_POSITIVE.value)
+
         if min > max:
             raise ValueError(ErrorMessage.MIN_MAX_INVALID_RANGE.value)
 

--- a/password_generator.py
+++ b/password_generator.py
@@ -79,7 +79,10 @@ class PasswordGenerator:
 
         return (min, max)
 
-    def adjust_length(self) -> None:
-        min, max = self.sum_range()
+    def adjust_length(self, sum_min: int, sum_max: int) -> tuple:
+        self.validate_adjust_range(sum_min, sum_max)
 
-        self.validate_adjust_range(min, max)
+        adjust_min = self.min if self.min > sum_min else sum_min
+        adjust_max = self.max if self.max < sum_max else sum_max
+
+        return (adjust_min, adjust_max)

--- a/password_generator.py
+++ b/password_generator.py
@@ -38,14 +38,14 @@ class PasswordGenerator:
                 raise TypeError(ErrorMessage.NOT_CHARACTER_TYPE.value)
 
     def validate_adjust_range(self, min: int, max: int) -> None:
+        if not max > 0:
+            raise ValueError(ErrorMessage.ADJUST_MAX_IS_ZERO.value)
+
         if min > self.max:
             raise ValueError(ErrorMessage.GENERATOR_MAX_LT_CHAR_TYPE_MIN.value)
 
         if max < self.min:
             raise ValueError(ErrorMessage.GENERATOR_MIN_GT_CHAR_TYPE_MAX.value)
-
-        if not max > 0:
-            raise ValueError(ErrorMessage.ADJUST_MAX_IS_ZERO.value)
 
     @property
     def min(self) -> int:

--- a/password_generator.py
+++ b/password_generator.py
@@ -44,6 +44,9 @@ class PasswordGenerator:
         if max < self.min:
             raise ValueError(ErrorMessage.GENERATOR_MIN_GT_CHAR_TYPE_MAX.value)
 
+        if not max > 0:
+            raise ValueError(ErrorMessage.ADJUST_MAX_IS_ZERO.value)
+
     @property
     def min(self) -> int:
         return self._min

--- a/password_generator.py
+++ b/password_generator.py
@@ -33,6 +33,10 @@ class PasswordGenerator:
         if not self.types:
             raise ValueError(ErrorMessage.EMPTY_CHAR_TYPE_LIST.value)
 
+        for char_type in self.types.values():
+            if type(char_type) != CharacterType:
+                raise TypeError(ErrorMessage.NOT_CHARACTER_TYPE.value)
+
     @property
     def min(self) -> int:
         return self._min

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -89,25 +89,29 @@ class TestPasswordGenerator(unittest.TestCase):
             with self.assertRaisesRegex(TypeError, expected):
                 self.generator.sum_range()
 
-    def adjust_length_range_with_worng_char_type_length_range(self) -> None:
+    def test_adjust_length_range_with_worng_length_range(self) -> None:
         min, max = self.generator.sum_range()
 
         self.generator.min = 0
         self.generator.max = min - 1
+
         expected = ErrorMessage.GENERATOR_MAX_LT_CHAR_TYPE_MIN.value
+
         with self.assertRaisesRegex(ValueError, expected):
             self.generator.adjust_length()
 
+        self.generator.max = max + 2
         self.generator.min = max + 1
-        self.generator.max = int(float("inf"))
+
         expected = ErrorMessage.GENERATOR_MIN_GT_CHAR_TYPE_MAX.value
+
         with self.assertRaisesRegex(ValueError, expected):
             self.generator.adjust_length()
 
-    def adjust_length_range_with_zero_max(self) -> None:
+    def test_adjust_length_range_with_zero_max(self) -> None:
         expected = ErrorMessage.ADJUST_MAX_IS_ZERO.value
 
-        for type in self.generator.types:
+        for type in self.generator.types.values():
             type.min = 0
             type.max = 0
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -104,6 +104,16 @@ class TestPasswordGenerator(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, expected):
             self.generator.adjust_length()
 
+    def adjust_length_range_with_zero_max(self) -> None:
+        expected = ErrorMessage.ADJUST_MAX_IS_ZERO.value
+
+        for type in self.generator.types:
+            type.min = 0
+            type.max = 0
+
+        with self.assertRaisesRegex(ValueError, expected):
+            self.generator.adjust_length()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2,6 +2,7 @@ import os
 import string
 import sys
 import unittest
+import random
 
 from password_generator import PasswordGenerator
 from error_message import ErrorMessage
@@ -55,6 +56,21 @@ class TestPasswordGenerator(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, expected):
                 self.generator.max = num
+
+    def test_sum_char_type_length_range(self) -> None:
+        expected_min = 0
+        expected_max = 0
+
+        for type in self.generator.types.values():
+            type.min = random.randrange(0, 5)
+            expected_min += type.min
+
+            type.max = random.randrange(5, 9)
+            expected_max += type.max
+
+        self.assertTupleEqual(
+            self.generator.sum_range(),
+            (expected_min, expected_max))
 
 
 if __name__ == '__main__':

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -79,6 +79,16 @@ class TestPasswordGenerator(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, expected):
             self.generator.sum_range()
 
+    def test_sum_char_type_length_range_with_other_types(self) -> None:
+        expected = ErrorMessage.NOT_CHARACTER_TYPE.value
+        other_types = ["str", 1, [1, 2], {"test": "t"}]
+
+        for other_type in other_types:
+            self.generator.types["none_character_type"] = other_type
+
+            with self.assertRaisesRegex(TypeError, expected):
+                self.generator.sum_range()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -30,7 +30,7 @@ class TestPasswordGenerator(unittest.TestCase):
     def test_set_min_greater_than_max(self):
         expected = ErrorMessage.MIN_MAX_INVALID_RANGE.value
 
-        for min in range(1, 10):
+        for min in range(2, 10):
             with self.assertRaisesRegex(ValueError, expected):
                 self.generator.min = min
                 self.generator.max = min - 1
@@ -46,7 +46,7 @@ class TestPasswordGenerator(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, expected):
                 self.generator.max = num
 
-    def test_set_negative_number_min_max(self) -> None:
+    def test_set_min_with_negative_number(self) -> None:
         nums = [-1, -3, -11]
         expected = ErrorMessage.MIN_MAX_NAGATIVE.value
 
@@ -54,8 +54,11 @@ class TestPasswordGenerator(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, expected):
                 self.generator.min = num
 
-            with self.assertRaisesRegex(ValueError, expected):
-                self.generator.max = num
+    def test_set_max_with_zero_number(self) -> None:
+        expected = ErrorMessage.GENERATOR_MAX_NOT_POSITIVE.value
+
+        with self.assertRaisesRegex(ValueError, expected):
+            self.generator.max = 0
 
     def test_sum_char_type_length_range(self) -> None:
         expected_min = 0

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -101,7 +101,7 @@ class TestPasswordGenerator(unittest.TestCase):
         expected = ErrorMessage.GENERATOR_MAX_LT_CHAR_TYPE_MIN.value
 
         with self.assertRaisesRegex(ValueError, expected):
-            self.generator.adjust_length()
+            self.generator.adjust_length(min, max)
 
         self.generator.max = max + 2
         self.generator.min = max + 1
@@ -109,7 +109,7 @@ class TestPasswordGenerator(unittest.TestCase):
         expected = ErrorMessage.GENERATOR_MIN_GT_CHAR_TYPE_MAX.value
 
         with self.assertRaisesRegex(ValueError, expected):
-            self.generator.adjust_length()
+            self.generator.adjust_length(min, max)
 
     def test_adjust_length_range_with_zero_max(self) -> None:
         expected = ErrorMessage.ADJUST_MAX_IS_ZERO.value
@@ -118,8 +118,27 @@ class TestPasswordGenerator(unittest.TestCase):
             type.min = 0
             type.max = 0
 
+        min, max = self.generator.sum_range()
+
         with self.assertRaisesRegex(ValueError, expected):
-            self.generator.adjust_length()
+            self.generator.adjust_length(min, max)
+
+    def test_adjust_length_range(self) -> None:
+        range = [
+            (self.generator.min - 1, self.generator.max - 1),
+            (self.generator.min + 1, self.generator.max - 1),
+            (self.generator.min + 1, self.generator.max + 1)
+        ]
+
+        expected = [
+            (self.generator.min, self.generator.max - 1),
+            (self.generator.min + 1, self.generator.max - 1),
+            (self.generator.min + 1, self.generator.max)
+        ]
+
+        for r, e in zip(range, expected):
+            min, max = self.generator.adjust_length(r[0], r[1])
+            self.assertTupleEqual((min, max), e)
 
 
 if __name__ == '__main__':

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -72,6 +72,13 @@ class TestPasswordGenerator(unittest.TestCase):
             self.generator.sum_range(),
             (expected_min, expected_max))
 
+    def test_sum_char_type_length_range_with_empty_types(self) -> None:
+        expected = ErrorMessage.EMPTY_CHAR_TYPE_LIST.value
+        self.generator.types = []
+
+        with self.assertRaisesRegex(ValueError, expected):
+            self.generator.sum_range()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -89,6 +89,21 @@ class TestPasswordGenerator(unittest.TestCase):
             with self.assertRaisesRegex(TypeError, expected):
                 self.generator.sum_range()
 
+    def adjust_length_range_with_worng_char_type_length_range(self) -> None:
+        min, max = self.generator.sum_range()
+
+        self.generator.min = 0
+        self.generator.max = min - 1
+        expected = ErrorMessage.GENERATOR_MAX_LT_CHAR_TYPE_MIN.value
+        with self.assertRaisesRegex(ValueError, expected):
+            self.generator.adjust_length()
+
+        self.generator.min = max + 1
+        self.generator.max = int(float("inf"))
+        expected = ErrorMessage.GENERATOR_MIN_GT_CHAR_TYPE_MAX.value
+        with self.assertRaisesRegex(ValueError, expected):
+            self.generator.adjust_length()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added a function to adjust the range of passwords to be actually generated by summing the length ranges of each string type.

The string range to be adjusted has the following conditions.

- If the minimum value "SUM_MIN" in the summed range is greater than the minimum value of the password generator, the minimum value of the password generator will be SUM_MIN.
- If the maximum value "SUM_MAX" of the summed range is less than the maximum value of the password generator, the maximum value of the password generator becomes SUM_MAX.
- The password generator's maximum length value cannot be zero.